### PR TITLE
[Mission4/김민재] - Project_Notion_VanillaJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 constants.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 constants.js
-storage.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+constants.js
+storage.js

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/style.css" />
+    <title>Minjae의 Notion</title>
+  </head>
+  <body>
+    <main id="app" style="display: flex; flex-direction: row"></main>
+    <script src="/src/main.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <title>Minjae의 Notion</title>
   </head>
   <body>
-    <main id="app" style="display: flex; flex-direction: row"></main>
+    <main id="app"></main>
     <script src="/src/main.js" type="module"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,82 @@
+import EditorContainer from "./components/editpage/EditorContainer.js";
+import Sidebar from "./components/sidebar/Sidebar.js";
+import { request } from "./api.js";
+import { initRouter, push } from "./router.js";
+import { validation } from "./validation.js";
+import LandingPage from "./components/editpage/LandingPage.js";
+
+export default function App({ $target }) {
+  validation(new.target, "App");
+
+  this.state = {
+    documentsList: [],
+    editorDocument: {
+      docId: null,
+      doc: {
+        title: "",
+        content: "",
+        documents: [],
+      },
+    },
+  };
+
+  const sidebar = new Sidebar({
+    $target,
+    initialState: this.state.documentsList,
+  });
+
+  new LandingPage({ $target });
+
+  const editContainer = new EditorContainer({
+    $target,
+    initialState: this.state.editorDocument,
+  });
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    editContainer.setState(this.state.editorDocument);
+  };
+
+  this.init = async () => {
+    const docs = await request("/documents");
+    this.setState({
+      ...this.state,
+      documentsList: docs,
+    });
+    await sidebar.setState(docs);
+    this.route();
+  };
+
+  this.route = () => {
+    const { pathname } = window.location;
+    const editArea = document.querySelector(".editContainer");
+    const landingPage = document.querySelector(".landingPage");
+
+    if (pathname === "/") {
+      editArea.style.display = "none";
+      landingPage.style.display = "block";
+    } else if (pathname.indexOf("/documents/") === 0) {
+      editArea.style.display = "block";
+      landingPage.style.display = "none";
+      const [, , docId] = pathname.split("/");
+      //같은 문서 두번 클릭시 내용 삭제 방지
+      if (this.state.editorDocument.docId === docId) {
+        return;
+      }
+      //뒤로가기 대비 방어코드
+      if (docId === null) {
+        push("/");
+      }
+      this.setState({
+        ...this.state,
+        editorDocument: { docId },
+      });
+    }
+  };
+
+  this.init();
+
+  window.addEventListener("popstate", () => this.route());
+
+  initRouter(() => this.route());
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,24 @@
+import { API_END_POINT } from "./constants.js";
+import { X_USERNAME } from "./constants.js";
+
+export const request = async (url, options = {}) => {
+  try {
+    const res = await fetch(`${API_END_POINT}${url}`, {
+      ...options,
+      headers: {
+        "x-username": X_USERNAME,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (res.ok) {
+      return await res.json();
+    }
+
+    throw new Error("API 처리중 뭔가 이상합니다!");
+  } catch (e) {
+    alert(e.message);
+    history.replaceState(null, null, "/");
+    location.reload();
+  }
+};

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,4 @@
-import { API_END_POINT } from "./constants.js";
-import { X_USERNAME } from "./constants.js";
+import { API_END_POINT, X_USERNAME } from "./constants.js";
 
 export const request = async (url, options = {}) => {
   try {

--- a/src/components/editpage/BreadCrumb.js
+++ b/src/components/editpage/BreadCrumb.js
@@ -1,0 +1,59 @@
+import { validation } from "../../validation.js";
+
+export default function BreadCrumb({ $target, initialState, clickPath }) {
+  validation(new.target, "BreadCrumb");
+
+  const $breadCrumb = document.createElement("nav");
+  $breadCrumb.className = "linkContainer";
+  $target.appendChild($breadCrumb);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.renderBreadCrumb = (id) => {
+    const path = [];
+
+    const recursiveBC = (id) => {
+      const $curLi = document.getElementById(id);
+      const $ul = $curLi.closest("ul");
+
+      if ($ul.className === "child") {
+        path.push([$curLi.querySelector("span").innerHTML, id]);
+
+        recursiveBC($ul.closest("li").id);
+      } else {
+        path.push([$curLi.querySelector("span").innerHTML, id]);
+      }
+    };
+
+    recursiveBC(id);
+
+    return path
+      .reverse()
+      .map((el) => `<span class="link" data-id=${el[1]} >${el[0]}</span>`)
+      .join(" / ");
+  };
+
+  $breadCrumb.addEventListener("click", (e) => {
+    const $span = e.target.closest("span");
+
+    if ($span) {
+      const { id } = $span.dataset;
+      clickPath(id);
+    }
+  });
+
+  this.render = () => {
+    const { docId } = this.state;
+
+    $breadCrumb.innerHTML = `
+      <div>
+        ${docId ? this.renderBreadCrumb(docId) : ""}
+      </div>
+    `;
+  };
+}

--- a/src/components/editpage/BreadCrumb.js
+++ b/src/components/editpage/BreadCrumb.js
@@ -19,7 +19,7 @@ export default function BreadCrumb({ $target, initialState, clickPath }) {
     if ($curLi) {
       const $ul = $curLi.closest("ul");
 
-      if ($ul.className === "child") {
+      if ($ul.className === "child" || $ul.className === "child--show") {
         path.push([$curLi.querySelector("span").innerHTML, id]);
 
         recursiveBC($ul.closest("li").id, path);

--- a/src/components/editpage/BreadCrumb.js
+++ b/src/components/editpage/BreadCrumb.js
@@ -5,13 +5,12 @@ export default function BreadCrumb({ $target, initialState, clickPath }) {
 
   const $breadCrumb = document.createElement("nav");
   $breadCrumb.className = "linkContainer";
-  $target.appendChild($breadCrumb);
-
   this.state = initialState;
 
   this.setState = (nextState) => {
     this.state = nextState;
     this.render();
+    $target.prepend($breadCrumb);
   };
 
   this.renderBreadCrumb = (id) => {

--- a/src/components/editpage/Editor.js
+++ b/src/components/editpage/Editor.js
@@ -28,8 +28,7 @@ export default function Editor({ $target, initialState, onEdit }) {
   this.render();
 
   $editor.addEventListener("keyup", (e) => {
-    const targetTag = e.target.tagName;
-    const { value } = e.target;
+    const { tagName: targetTag, value } = e.target;
     let nextState = {};
     if (targetTag === "INPUT") {
       nextState = { ...this.state, title: value };

--- a/src/components/editpage/Editor.js
+++ b/src/components/editpage/Editor.js
@@ -1,0 +1,46 @@
+import { validation } from "../../validation.js";
+
+export default function Editor({ $target, initialState, onEdit }) {
+  validation(new.target, "Editor");
+  const $editor = document.createElement("div");
+  $editor.className = "editor";
+  $target.appendChild($editor);
+
+  $editor.innerHTML = `
+          <div style="display: flex; flex-direction: column">
+            <input type="text" placeholder="제목 없음" name="title" style="height:100px" />
+            <textarea name="content" placeholder="내용을 입력하세요" style="height:75vh;"></textarea>
+          </div>
+        `;
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {
+    $editor.querySelector("[name=title]").value = this.state.title;
+    $editor.querySelector("[name=content]").value = this.state.content;
+  };
+
+  this.render();
+
+  $editor.addEventListener("keyup", (e) => {
+    const targetTag = e.target.tagName;
+    const { value } = e.target;
+    let nextState = {};
+    if (targetTag === "INPUT") {
+      nextState = { ...this.state, title: value };
+    } else {
+      nextState = {
+        ...this.state,
+        content: value,
+      };
+    }
+
+    this.setState(nextState);
+    onEdit(this.state);
+  });
+}

--- a/src/components/editpage/EditorContainer.js
+++ b/src/components/editpage/EditorContainer.js
@@ -1,0 +1,80 @@
+import { request } from "../../api.js";
+import BreadCrumb from "./BreadCrumb.js";
+import Editor from "./Editor.js";
+import { push } from "../../router.js";
+import SubLink from "./SubLink.js";
+import { validation } from "../../validation.js";
+
+//여기에선 docId만 핸들, Editor에는 Doc만
+export default function EditorContainer({ $target, initialState }) {
+  validation(new.target, "EditorContainer");
+
+  const $editorContainer = document.createElement("section");
+  $editorContainer.className = "editContainer";
+
+  this.state = initialState;
+
+  let timer = null;
+
+  const breadCrumb = new BreadCrumb({
+    $target: $editorContainer,
+    initialState: this.state,
+    clickPath: (id) => {
+      push(`/documents/${id}`);
+    },
+  });
+
+  const editor = new Editor({
+    $target: $editorContainer,
+    initialState: this.state.doc,
+    onEdit: (post) => {
+      document.getElementById(post.id).getElementsByTagName("span")[0].innerText = post.title;
+
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(async () => {
+        await request(`/documents/${post.id}`, {
+          method: "PUT",
+          body: JSON.stringify(post),
+        });
+      }, 500);
+    },
+  });
+
+  const subLink = new SubLink({
+    $target: $editorContainer,
+    initialState: this.state,
+    clickLink: (id) => {
+      push(`/documents/${id}`);
+    },
+  });
+
+  this.setState = async (nextState) => {
+    if (this.state.docId !== nextState.docId) {
+      this.state = nextState;
+      await fetchDoc();
+      return;
+    }
+    this.state = nextState;
+
+    this.render();
+    breadCrumb.setState(this.state);
+    subLink.setState(this.state);
+    editor.setState(this.state.doc || { title: "", content: "" });
+  };
+
+  this.render = () => {
+    $target.appendChild($editorContainer);
+  };
+
+  const fetchDoc = async () => {
+    const { docId } = this.state;
+    const doc = await request(`/documents/${docId}`);
+
+    this.setState({
+      ...this.state,
+      doc,
+    });
+  };
+}

--- a/src/components/editpage/EditorContainer.js
+++ b/src/components/editpage/EditorContainer.js
@@ -20,6 +20,7 @@ export default function EditorContainer({ $target, initialState }) {
     $target: $editorContainer,
     initialState: this.state,
     clickPath: (id) => {
+      changeHoverEffect(this.state, id);
       push(`/documents/${id}`);
     },
   });
@@ -46,6 +47,7 @@ export default function EditorContainer({ $target, initialState }) {
     $target: $editorContainer,
     initialState: this.state,
     clickLink: (id) => {
+      changeHoverEffect(this.state, id);
       push(`/documents/${id}`);
     },
   });
@@ -76,5 +78,15 @@ export default function EditorContainer({ $target, initialState }) {
       ...this.state,
       doc,
     });
+  };
+
+  const changeHoverEffect = (prev, curr) => {
+    const { docId } = prev;
+    if (docId) {
+      const $prevLi = document.getElementById(docId);
+      const $currLi = document.getElementById(curr);
+      $prevLi.querySelector("p").style = "";
+      $currLi.querySelector("p").style.backgroundColor = "rgba(0, 0, 0, 0.1)";
+    }
   };
 }

--- a/src/components/editpage/EditorContainer.js
+++ b/src/components/editpage/EditorContainer.js
@@ -58,10 +58,10 @@ export default function EditorContainer({ $target, initialState }) {
     }
     this.state = nextState;
 
-    this.render();
     breadCrumb.setState(this.state);
     subLink.setState(this.state);
     editor.setState(this.state.doc || { title: "", content: "" });
+    this.render();
   };
 
   this.render = () => {

--- a/src/components/editpage/LandingPage.js
+++ b/src/components/editpage/LandingPage.js
@@ -1,0 +1,20 @@
+import { validation } from "../../validation.js";
+
+export default function LandingPage({ $target }) {
+  validation(new.target, "LandingPage");
+
+  const $landingPage = document.createElement("section");
+  $landingPage.className = "landingPage";
+  $target.appendChild($landingPage);
+
+  this.render = () => {
+    $landingPage.innerHTML = `
+            <h1 class="landingTitle">
+                Notion에 오신 것을 환영합니다.
+            </h1>
+            <p class="landingP">페이지를 추가하여 새 문서를 작성해보세요.</p>
+        `;
+  };
+
+  this.render();
+}

--- a/src/components/editpage/SubLink.js
+++ b/src/components/editpage/SubLink.js
@@ -1,0 +1,38 @@
+import { validation } from "../../validation.js";
+export default function SubLink({ $target, initialState, clickLink }) {
+  validation(new.target, "SubLink");
+
+  const $subLink = document.createElement("footer");
+  $subLink.className = "linkContainer";
+  $target.appendChild($subLink);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {
+    const { doc } = this.state;
+
+    if (doc.documents.length > 0) {
+      $subLink.innerHTML = doc.documents
+        .map((el) => `<div class="link" data-id=${el.id}>${el.title}</div>`)
+        .join("");
+    } else {
+      $subLink.innerHTML = `
+        `;
+    }
+  };
+
+  $subLink.addEventListener("click", (e) => {
+    const { id } = e.target.closest("div").dataset;
+    const $curLi = document.getElementById(id);
+    const $parentUl = $curLi.closest("ul");
+
+    $parentUl.closest("li").querySelector(".toggleFold").innerText = "▼";
+    $parentUl.style.display = "block";
+    clickLink(id);
+  });
+}

--- a/src/components/editpage/SubLink.js
+++ b/src/components/editpage/SubLink.js
@@ -16,23 +16,21 @@ export default function SubLink({ $target, initialState, clickLink }) {
   this.render = () => {
     const { doc } = this.state;
 
-    if (doc.documents.length > 0) {
-      $subLink.innerHTML = doc.documents
-        .map((el) => `<div class="link" data-id=${el.id}>${el.title}</div>`)
-        .join("");
-    } else {
-      $subLink.innerHTML = `
-        `;
-    }
+    $subLink.innerHTML =
+      doc.documents.length > 0
+        ? doc.documents.map((el) => `<div class="link" data-id=${el.id}>${el.title}</div>`).join("")
+        : ``;
   };
 
   $subLink.addEventListener("click", (e) => {
     const { id } = e.target.closest("div").dataset;
-    const $curLi = document.getElementById(id);
-    const $parentUl = $curLi.closest("ul");
+    if (id) {
+      const $curLi = document.getElementById(id);
+      const $parentUl = $curLi.closest("ul");
 
-    $parentUl.closest("li").querySelector(".toggleFold").innerText = "▼";
-    $parentUl.style.display = "block";
-    clickLink(id);
+      $parentUl.closest("li").querySelector(".toggleFold").innerText = "▼";
+      $parentUl.style.display = "block";
+      clickLink(id);
+    }
   });
 }

--- a/src/components/editpage/SubLink.js
+++ b/src/components/editpage/SubLink.js
@@ -29,7 +29,7 @@ export default function SubLink({ $target, initialState, clickLink }) {
       const $parentUl = $curLi.closest("ul");
 
       $parentUl.closest("li").querySelector(".toggleFold").innerText = "▼";
-      $parentUl.style.display = "block";
+      $parentUl.className = "child--show";
       clickLink(id);
     }
   });

--- a/src/components/sidebar/DocList.js
+++ b/src/components/sidebar/DocList.js
@@ -1,0 +1,108 @@
+import { validation } from "../../validation.js";
+
+export default function DocList({ $target, initialState, onClick, onNewSubDoc, onDelete }) {
+  validation(new.target, "DocList");
+
+  const $docList = document.createElement("nav");
+  $docList.className = "docList";
+  $target.appendChild($docList);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  const renderDocList = (docs) => {
+    return docs
+      .map(
+        ({ id, title, documents }, i) => `
+        <li id=${id} data-id=${id} class="docItem">
+          <p class="forHover">
+            <button class="toggleFold">►</button>
+            <span class="docTitle">${title}</span>
+            <span class="controlBtns">
+              <button class="newSubDoc">➕</button> 
+              <button class="delete">X</button>
+            </span>
+            ${
+              documents.length > 0
+                ? `<ul class='child' style='display: none;'>${renderDocList(documents)}</ul>`
+                : `<ul class='child' style='display: none;'><li class="isEnd">하위 페이지가 없습니다.</li></ul>`
+            }
+          </p>
+        </li>`
+      )
+      .join("");
+  };
+
+  this.render = () => {
+    $docList.innerHTML = `
+        <ul>
+          ${renderDocList(this.state)}
+        </ul>
+      `;
+  };
+
+  this.render();
+
+  $docList.addEventListener("click", async (e) => {
+    const $li = e.target.closest("li");
+
+    if (!$li) return;
+    const { id } = $li.dataset;
+    const { className } = e.target;
+
+    if (className === "toggleFold") {
+      const $childUl = $li.getElementsByClassName("child");
+
+      if ($childUl.length > 0) {
+        const toggleDisplay = $childUl[0].style.display === "block" ? "none" : "block";
+
+        $li.querySelector(".toggleFold").innerText = toggleDisplay === "block" ? "▼" : "►";
+        $childUl[0].style.display = toggleDisplay;
+      }
+      return;
+    }
+    if (className === "newSubDoc") {
+      const $childUl = $li.getElementsByClassName("child");
+      const $isEnd = $childUl[0].querySelector(".isEnd");
+      const $newSubDoc = document.createElement("li");
+
+      if ($childUl.length > 0) {
+        $childUl[0].style.display = "block";
+        $li.querySelector(".toggleFold").innerText = "block" ? "▼" : "►";
+      }
+
+      if ($isEnd) {
+        $isEnd.remove();
+      }
+      $newSubDoc.id = "newSubDoc";
+      $newSubDoc.className = "docItem";
+
+      $childUl[0].appendChild($newSubDoc);
+      $newSubDoc.innerHTML = `
+        <p class="forHover">
+          <button class="toggleFold">►</button>
+          <span class="docTitle">제목 없음</span>
+          <span class="controlBtns">
+            <button class="newSubDoc">➕</button> 
+            <button class="delete">X</button>
+          </span>
+          <ul class='child' style='display: none;'><li class="isEnd">하위 페이지가 없습니다.</li></ul>
+        </p>
+      `;
+      await onNewSubDoc(id);
+      return;
+    }
+    if (className === "delete") {
+      if (confirm("이 문서를 삭제하시겠습니까?")) {
+        $li.remove();
+        onDelete(id);
+      }
+      return;
+    }
+    onClick(id);
+  });
+}

--- a/src/components/sidebar/DocList.js
+++ b/src/components/sidebar/DocList.js
@@ -20,11 +20,11 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
         ({ id, title, documents }, i) => `
         <li id=${id} data-id=${id} class="docItem">
           <p class="forHover">
-            <button class="toggleFold">►</button>
+            <button class="toggleFold btn">►</button>
             <span class="docTitle">${title}</span>
             <span class="controlBtns">
-              <button class="newSubDoc">➕</button> 
-              <button class="delete">X</button>
+              <button class="newSubDoc btn">➕</button> 
+              <button class="delete btn">X</button>
             </span>
             ${
               documents.length > 0
@@ -52,9 +52,9 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
 
     if (!$li) return;
     const { id } = $li.dataset;
-    const { className } = e.target;
+    const { classList } = e.target;
 
-    if (className === "toggleFold") {
+    if (classList.contains("toggleFold")) {
       const $childUl = $li.getElementsByTagName("ul");
       if ($childUl) {
         const toggleDisplay = $childUl[0].classList.contains("child");
@@ -63,7 +63,7 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
       }
       return;
     }
-    if (className === "newSubDoc") {
+    if (classList.contains("newSubDoc")) {
       const $childUl = $li.getElementsByTagName("ul");
       const $isEnd = $childUl[0].querySelector(".isEnd");
       const $newSubDoc = document.createElement("li");
@@ -82,11 +82,11 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
       $childUl[0].appendChild($newSubDoc);
       $newSubDoc.innerHTML = `
         <p class="forHover">
-          <button class="toggleFold">►</button>
+          <button class="toggleFold btn">►</button>
           <span class="docTitle">제목 없음</span>
           <span class="controlBtns">
-            <button class="newSubDoc">➕</button> 
-            <button class="delete">X</button>
+            <button class="newSubDoc btn">➕</button> 
+            <button class="delete btn">X</button>
           </span>
           <ul class='child'><li class="isEnd">하위 페이지가 없습니다.</li></ul>
         </p>
@@ -94,7 +94,7 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
       onNewSubDoc(id);
       return;
     }
-    if (className === "delete") {
+    if (classList.contains("delete")) {
       if (confirm("이 문서를 삭제하시겠습니까?")) {
         $li.remove();
         onDelete(id);

--- a/src/components/sidebar/DocList.js
+++ b/src/components/sidebar/DocList.js
@@ -28,8 +28,8 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
             </span>
             ${
               documents.length > 0
-                ? `<ul class='child' style='display: none;'>${renderDocList(documents)}</ul>`
-                : `<ul class='child' style='display: none;'><li class="isEnd">하위 페이지가 없습니다.</li></ul>`
+                ? `<ul class='child'>${renderDocList(documents)}</ul>`
+                : `<ul class='child'><li class="isEnd">하위 페이지가 없습니다.</li></ul>`
             }
           </p>
         </li>`
@@ -47,7 +47,7 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
 
   this.render();
 
-  $docList.addEventListener("click", async (e) => {
+  $docList.addEventListener("click", (e) => {
     const $li = e.target.closest("li");
 
     if (!$li) return;
@@ -55,24 +55,22 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
     const { className } = e.target;
 
     if (className === "toggleFold") {
-      const $childUl = $li.getElementsByClassName("child");
-
-      if ($childUl.length > 0) {
-        const toggleDisplay = $childUl[0].style.display === "block" ? "none" : "block";
-
-        $li.querySelector(".toggleFold").innerText = toggleDisplay === "block" ? "▼" : "►";
-        $childUl[0].style.display = toggleDisplay;
+      const $childUl = $li.getElementsByTagName("ul");
+      if ($childUl) {
+        const toggleDisplay = $childUl[0].classList.contains("child");
+        $childUl[0].className = toggleDisplay ? "child--show" : "child";
+        $li.querySelector(".toggleFold").innerText = toggleDisplay ? "▼" : "►";
       }
       return;
     }
     if (className === "newSubDoc") {
-      const $childUl = $li.getElementsByClassName("child");
+      const $childUl = $li.getElementsByTagName("ul");
       const $isEnd = $childUl[0].querySelector(".isEnd");
       const $newSubDoc = document.createElement("li");
 
       if ($childUl.length > 0) {
-        $childUl[0].style.display = "block";
-        $li.querySelector(".toggleFold").innerText = "block" ? "▼" : "►";
+        $childUl[0].className = "child--show";
+        $li.querySelector(".toggleFold").innerText = "▼";
       }
 
       if ($isEnd) {
@@ -90,10 +88,10 @@ export default function DocList({ $target, initialState, onClick, onNewSubDoc, o
             <button class="newSubDoc">➕</button> 
             <button class="delete">X</button>
           </span>
-          <ul class='child' style='display: none;'><li class="isEnd">하위 페이지가 없습니다.</li></ul>
+          <ul class='child'><li class="isEnd">하위 페이지가 없습니다.</li></ul>
         </p>
       `;
-      await onNewSubDoc(id);
+      onNewSubDoc(id);
       return;
     }
     if (className === "delete") {

--- a/src/components/sidebar/NewRootDoc.js
+++ b/src/components/sidebar/NewRootDoc.js
@@ -1,0 +1,21 @@
+import { validation } from "../../validation.js";
+
+export default function NewRootDoc({ $target, initialState, onClick }) {
+  validation(new.target, "NewRootDoc");
+
+  const $newRootDoc = document.createElement("div");
+  $newRootDoc.className = "newRootDoc";
+  $target.appendChild($newRootDoc);
+
+  this.state = initialState;
+
+  $newRootDoc.addEventListener("click", () => {
+    onClick();
+  });
+
+  this.render = () => {
+    $newRootDoc.textContent = this.state.text;
+  };
+
+  this.render();
+}

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -30,7 +30,7 @@ export default function Sidebar({ $target, initialState }) {
         // 선택된 문서 배경색을 변화시켜 구분
         const { pathname } = window.location;
         const [, , docId] = pathname.split("/");
-        if (docId !== null) {
+        if (docId) {
           const $prevLiP = document.getElementById(docId).querySelector(".forHover");
           $prevLiP.style = "";
         }

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -49,10 +49,19 @@ export default function Sidebar({ $target, initialState }) {
         }),
       });
 
+      const { pathname } = window.location;
+      const [, , docId] = pathname.split("/");
       const $curLi = document.getElementById("newSubDoc");
 
+      if (docId) {
+        const $prevLiP = document.getElementById(docId).querySelector(".forHover");
+        $prevLiP.style = "";
+      }
+
+      $curLi.querySelector(".forHover").style.backgroundColor = "rgba(0, 0, 0, 0.1)";
       $curLi.id = newSubDoc.id;
       $curLi.dataset["id"] = newSubDoc.id;
+
       push(`/documents/${newSubDoc.id}`);
     },
     onDelete: async (id) => {
@@ -73,12 +82,15 @@ export default function Sidebar({ $target, initialState }) {
         const $parentLi = document.getElementById(res.parent.id);
         // 이미 상위 페이지가 지워진 경우 방어 코드
         if ($parentLi) {
+          const $currLiP = $parentLi.querySelector(".forHover");
           const $childUl = $parentLi.querySelector(".child");
+
           if ($childUl.innerText === "") {
             $childUl.innerHTML = `
               <li class="isEnd">하위 페이지가 없습니다.</li>
             `;
           }
+          $currLiP.style.backgroundColor = "rgba(0, 0, 0, 0.1)";
           push(`/documents/${res.parent.id}`);
         } else {
           this.setState();

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -72,14 +72,13 @@ export default function Sidebar({ $target, initialState }) {
       } else {
         const $parentLi = document.getElementById(res.parent.id);
         // 이미 상위 페이지가 지워진 경우 방어 코드
-        if ($parentLi !== null) {
+        if ($parentLi) {
           const $childUl = $parentLi.querySelector(".child");
           if ($childUl.innerText === "") {
             $childUl.innerHTML = `
               <li class="isEnd">하위 페이지가 없습니다.</li>
             `;
           }
-          this.setState();
           push(`/documents/${res.parent.id}`);
         } else {
           this.setState();
@@ -121,6 +120,7 @@ export default function Sidebar({ $target, initialState }) {
         </p>
       `;
       }
+      $rootUl.appendChild($li);
       push(`/documents/${newRootDoc.id}`);
       this.setState();
     },

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -1,0 +1,140 @@
+import DocList from "./DocList.js";
+import NewRootDoc from "./NewRootDoc.js";
+import SidebarTitle from "./SidebarTitle.js";
+import { request } from "../../api.js";
+import { push } from "../../router.js";
+import { validation } from "../../validation.js";
+
+export default function Sidebar({ $target, initialState }) {
+  validation(new.target, "Sidebar");
+
+  const $sidebar = document.createElement("nav");
+  $sidebar.className = "sideBar";
+
+  this.state = initialState;
+
+  new SidebarTitle({
+    $target: $sidebar,
+    text: "📑 Minjae의 Notion",
+    onClick: () => {
+      push("/");
+    },
+  });
+
+  const docList = new DocList({
+    $target: $sidebar,
+    initialState: this.state,
+    onClick: (id) => {
+      // 하위 페이지가 없습니다.를 클릭했을때 방어 코드
+      if (id) {
+        // 선택된 문서 배경색을 변화시켜 구분
+        const { pathname } = window.location;
+        const [, , docId] = pathname.split("/");
+        if (docId !== null) {
+          const $prevLiP = document.getElementById(docId).querySelector(".forHover");
+          $prevLiP.style = "";
+        }
+        const $curLiP = document.getElementById(id).querySelector(".forHover");
+        $curLiP.style.backgroundColor = "rgba(0, 0, 0, 0.1)";
+
+        push(`/documents/${id}`);
+      }
+    },
+    onNewSubDoc: async (id) => {
+      const newSubDoc = await request("/documents", {
+        method: "POST",
+        body: JSON.stringify({
+          title: "제목 없음",
+          parent: id,
+        }),
+      });
+
+      const $curLi = document.getElementById("newSubDoc");
+
+      $curLi.id = newSubDoc.id;
+      $curLi.dataset["id"] = newSubDoc.id;
+      push(`/documents/${newSubDoc.id}`);
+    },
+    onDelete: async (id) => {
+      if (id === undefined) {
+        this.setState();
+        return;
+      }
+
+      const res = await request(`/documents/${id}`, {
+        method: "DELETE",
+      });
+
+      // root 문서 삭제시 랜딩페이지로 돌아간다.
+      if (!res.parent) {
+        this.setState();
+        push("/");
+      } else {
+        const $parentLi = document.getElementById(res.parent.id);
+        // 이미 상위 페이지가 지워진 경우 방어 코드
+        if ($parentLi !== null) {
+          const $childUl = $parentLi.querySelector(".child");
+          if ($childUl.innerText === "") {
+            $childUl.innerHTML = `
+              <li class="isEnd">하위 페이지가 없습니다.</li>
+            `;
+          }
+          this.setState();
+          push(`/documents/${res.parent.id}`);
+        } else {
+          this.setState();
+        }
+      }
+    },
+  });
+
+  new NewRootDoc({
+    $target: $sidebar,
+    initialState: {
+      text: "+ 페이지 추가",
+    },
+    onClick: async () => {
+      const $li = document.createElement("li");
+      $li.className = "docItem";
+      const newRootDoc = await request("/documents", {
+        method: "POST",
+        body: JSON.stringify({
+          title: "제목 없음",
+          parent: null,
+        }),
+      });
+      $li.id = newRootDoc.id;
+      $li.dataset.id = newRootDoc.id;
+      const $rootUl = document.querySelector("ul");
+      if ($rootUl) {
+        $li.innerHTML = `
+        <p class="forHover">
+          <button class="toggleFold">►</button>
+          <span class="docTitle">제목 없음</span>
+          <span class="controlBtns">
+            <button class="newSubDoc">➕</button> 
+            <button class="delete">X</button>
+          </span>
+          <ul class='child' style='display: none;'>
+            <li class="isEnd">하위 페이지가 없습니다.</li>
+          </ul>
+        </p>
+      `;
+      }
+      push(`/documents/${newRootDoc.id}`);
+      this.setState();
+    },
+  });
+
+  this.setState = async () => {
+    const lists = await request(`/documents`);
+
+    docList.setState(lists);
+  };
+
+  this.render = () => {
+    $target.prepend($sidebar);
+  };
+
+  this.render();
+}

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -83,7 +83,7 @@ export default function Sidebar({ $target, initialState }) {
         // 이미 상위 페이지가 지워진 경우 방어 코드
         if ($parentLi) {
           const $currLiP = $parentLi.querySelector(".forHover");
-          const $childUl = $parentLi.querySelector(".child");
+          const $childUl = $parentLi.querySelector("ul");
 
           if ($childUl.innerText === "") {
             $childUl.innerHTML = `

--- a/src/components/sidebar/SidebarTitle.js
+++ b/src/components/sidebar/SidebarTitle.js
@@ -1,0 +1,18 @@
+import { validation } from "../../validation.js";
+
+export default function SidebarTitle({ $target, text, onClick }) {
+  validation(new.target, "SidebarTitle");
+  const $sidebarTitle = document.createElement("header");
+  $sidebarTitle.className = "sidebarTitle";
+  $target.appendChild($sidebarTitle);
+
+  $sidebarTitle.addEventListener("click", () => {
+    onClick();
+  });
+
+  this.render = () => {
+    $sidebarTitle.textContent = text;
+  };
+
+  this.render();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,5 @@
+import App from "./App.js";
+
+const $target = document.querySelector("#app");
+
+new App({ $target });

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,22 @@
+const ROUTE_CHANGE_EVENT_NAME = "route-change";
+
+export const initRouter = (onRoute) => {
+  window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+    const { nextUrl } = e.detail;
+
+    if (nextUrl) {
+      history.pushState(null, null, nextUrl);
+      onRoute();
+    }
+  });
+};
+
+export const push = (nextUrl) => {
+  window.dispatchEvent(
+    new CustomEvent("route-change", {
+      detail: {
+        nextUrl,
+      },
+    })
+  );
+};

--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,7 @@ export const initRouter = (onRoute) => {
 
 export const push = (nextUrl) => {
   window.dispatchEvent(
-    new CustomEvent("route-change", {
+    new CustomEvent(ROUTE_CHANGE_EVENT_NAME, {
       detail: {
         nextUrl,
       },

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,18 @@
+const storage = window.localStorage;
+
+export const getItem = (key, defaultValue) => {
+  try {
+    const storedValue = storage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : defaultValue;
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+export const setItem = (key, value) => {
+  storage.setItem(key, JSON.stringify(value));
+};
+
+export const removeItem = (key) => {
+  storage.removeItem(key);
+};

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,0 +1,4 @@
+export const validation = (target, component) => {
+  if (!target)
+    throw new Error(`${component} 컴포넌트는 생성자 함수입니다. new 키워드를 추가해주세요.`);
+};

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,4 +1,9 @@
 export const validation = (target, component) => {
-  if (!target)
+  if (!target) {
     throw new Error(`${component} 컴포넌트는 생성자 함수입니다. new 키워드를 추가해주세요.`);
+  }
+};
+
+export const checkDifference = (prev, curr) => {
+  return JSON.stringify(prev) === JSON.stringify(curr) ? true : false;
 };

--- a/style.css
+++ b/style.css
@@ -1,3 +1,11 @@
+:root {
+  --black: rgb(55, 53, 47);
+  --grey100: rgba(25, 23, 17, 0.6);
+  --white: rgb(251, 251, 250);
+  --outline: rgb(245, 245, 239);
+  --grey200: rgba(0, 0, 0, 0.1);
+}
+
 html,
 body,
 div,
@@ -152,7 +160,7 @@ ul {
 }
 
 .sidebarTitle {
-  color: rgb(55, 53, 47);
+  color: var(--black);
   padding: 15px 14px;
   margin: 1px 0px;
   font-weight: 600;
@@ -162,8 +170,8 @@ ul {
 
 .sideBar {
   height: 100%;
-  background-color: rgb(251, 251, 250);
-  outline: 1px solid rgb(245, 245, 239);
+  background-color: var(--white);
+  outline: 1px solid var(--outline);
   min-width: 240px;
   max-width: 26%;
 }
@@ -175,7 +183,7 @@ ul {
 
 .docList,
 .newRootDoc {
-  color: rgba(25, 23, 17, 0.6);
+  color: var(--grey100);
   padding-left: 5px;
   padding-bottom: 5px;
   font-size: 14px;
@@ -192,12 +200,12 @@ ul {
 }
 
 .editor {
-  color: rgb(55, 53, 47);
+  color: var(--black);
   height: 80%;
 }
 
 .linkContainer {
-  color: rgba(25, 23, 17, 0.6);
+  color: var(--grey100);
   padding-top: 16px;
   padding-left: 10px;
 }
@@ -209,8 +217,8 @@ ul {
   text-decoration: underline;
 }
 
-button {
-  color: rgba(25, 23, 17, 0.6);
+.btn {
+  color: var(--grey100);
   border: 0;
   padding: 2px;
   background-color: transparent;
@@ -247,7 +255,7 @@ button {
 }
 
 .forHover:hover {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--grey200);
 }
 
 .forHover:hover .controlBtns {
@@ -280,7 +288,7 @@ textarea {
   max-width: 100%;
   white-space: pre-wrap;
   word-break: break-word;
-  caret-color: rgb(55, 53, 47);
+  caret-color: var(--black);
 }
 
 .landingPage {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,293 @@
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+html,
+body,
+main {
+  height: 100%;
+  width: 100%;
+  font-size: 16px;
+}
+
+ul {
+  list-style: none;
+  padding-inline-start: 0px;
+}
+
+.child {
+  padding-left: 15px;
+}
+
+.sidebarTitle {
+  color: rgb(55, 53, 47);
+  padding: 15px 14px;
+  margin: 1px 0px;
+  font-weight: 600;
+  align-items: center;
+  overflow: hidden;
+}
+
+.sideBar {
+  height: 100%;
+  background-color: rgb(251, 251, 250);
+  outline: 1px solid rgb(245, 245, 239);
+  min-width: 240px;
+  max-width: 26%;
+}
+
+.docList {
+  max-height: 80%;
+  overflow: auto;
+}
+
+.docList,
+.newRootDoc {
+  color: rgba(25, 23, 17, 0.6);
+  padding-left: 5px;
+  padding-bottom: 5px;
+  font-size: 14px;
+}
+
+.newRootDoc {
+  cursor: pointer;
+  padding-left: 13px;
+  padding-top: 5px;
+}
+
+.editContainer {
+  width: 100%;
+}
+
+.editor {
+  color: rgb(55, 53, 47);
+  height: 80%;
+}
+
+.linkContainer {
+  color: rgba(25, 23, 17, 0.6);
+  padding-top: 16px;
+  padding-left: 10px;
+}
+.link {
+  cursor: pointer;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+button {
+  color: rgba(25, 23, 17, 0.6);
+  border: 0;
+  padding: 2px;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.docItem {
+  width: 100%;
+  padding: 3px 0px;
+  align-items: center;
+  max-width: 240px;
+  position: relative;
+}
+
+.docItem .forHover {
+  padding: 3px 0px;
+}
+
+.docTitle {
+  display: inline-block;
+  max-width: 170px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.controlBtns {
+  position: absolute;
+  top: 5px;
+  right: 2px;
+  display: none;
+}
+
+.forHover:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.forHover:hover .controlBtns {
+  display: block;
+}
+
+.isEnd {
+  margin-top: 5px;
+  padding-left: 5px;
+}
+
+ul .child {
+  padding-top: 4px;
+}
+
+input,
+textarea {
+  outline: none;
+  border: none;
+  padding-left: 96px;
+}
+
+input {
+  font-size: 30px;
+  font-weight: 700;
+}
+
+textarea {
+  font-size: 15px;
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+  caret-color: rgb(55, 53, 47);
+}
+
+.landingPage {
+  width: 70%;
+  min-width: 650px;
+  height: 80%;
+  padding-top: 120px;
+  padding-left: 96px;
+  opacity: 0.5;
+}
+
+.landingTitle {
+  width: 100%;
+  font-size: 40px;
+  font-weight: 600;
+}
+
+.landingP {
+  width: 100%;
+  padding-top: 25px;
+  font-size: 18px;
+}

--- a/style.css
+++ b/style.css
@@ -131,6 +131,11 @@ main {
   font-size: 16px;
 }
 
+#app {
+  display: flex;
+  flex-direction: row;
+}
+
 ul {
   list-style: none;
   padding-inline-start: 0px;

--- a/style.css
+++ b/style.css
@@ -207,6 +207,7 @@ button {
 }
 
 .docItem {
+  cursor: pointer;
   width: 100%;
   padding: 3px 0px;
   align-items: center;

--- a/style.css
+++ b/style.css
@@ -142,6 +142,12 @@ ul {
 }
 
 .child {
+  display: none;
+  padding-left: 15px;
+}
+
+.child--show {
+  display: block;
   padding-left: 15px;
 }
 


### PR DESCRIPTION
## 📌 과제 설명 

- 바닐라 JS만을 이용해 노션 클로닝을 진행하였습니다.
- 초기 목표는 최소한으로 데이터를 fetch하는 것을 목표로 하였습니다.
- 스타일을 줄 때에는 CSS와 자바스크립트 inline 모두 활용하여 주었습니다.

## 👩‍💻 요구 사항과 구현 내용

기본 요구사항으로 제공된 내용은 모두 구현하였고 보너스는 한가지 구현하였습니다.

###  구현한 기본 요구사항
- 글 단위를 Document라고 합니다. Document는 Document 여러개를 포함할 수 있습니다.
- 화면 좌측에 Root Documents를 불러오는 API를 통해 루트 Documents를 렌더링합니다.
   - Root Document를 클릭하면 오른쪽 편집기 영역에 해당 Document의 Content를 렌더링합니다.
   - 해당 Root Document에 하위 Document가 있는 경우, 해당 Document 아래에 트리 형태로 렌더링 합니다.
   - Document Tree에서 각 Document 우측에는 + 버튼이 있습니다. 해당 버튼을 클릭하면, 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면으로 넘깁니다.
- 편집기에는 기본적으로 저장 버튼이 없습니다. Document Save API를 이용해 지속적으로 서버에 저장되도록 합니다.
- History API를 이용해 SPA 형태로 만듭니다.
   - 루트 URL 접속 시엔 별다른 편집기 선택이 안 된 상태입니다.
   - /documents/{documentId} 로 접속시, 해당 Document 의 content를 불러와 편집기에 로딩합니다.
### 구현한 보너스 요구사항
- 편집기 최하단에는 현재 편집 중인 Document의 하위 Document 링크를 렌더링하도록 추가합니다.

<p align="center"><img width="700" alt="스크린샷 2022-11-16 시간: 22 17 28" src="https://user-images.githubusercontent.com/82329983/202191508-5d456f33-41a4-4feb-a97a-9f24051ee80a.png"></p>
<p align="center">미리보기</p>

## ✅ 피드백 반영사항 

- [x] route 누락된 변수 사용
- [x] api 중복 바인딩 한줄로 처리
- [x] HTML inline style 속성을 CSS로 수정
- [x] breadcrumb breadcrumb 방어코드, 메서드 분리, validation 추가"
- [x] validation 조건문 괄호 처리, checkdiffrence 함수 추가
- [x] storage 사용하지 않는 파일 정리
- [x] Editor 이벤트 디스트럭팅 변수 개선
- [x] SubLink 삼항연산자로 render 수정, 방어코드 추가
- [x] class로 display 속성 변경, 불필요한 async 삭제 
- [x] btn 클래스 추가, css 변수 추가

## ✅ PR 포인트 & 궁금한 점
우선 이번 과제를 진행하며 부족함을 많이 느꼈습니다..😔 의존성이 많이 발생했다고 느끼고 있습니다.

초기 계획으로는 문서 리스트를 한번만 불러오고 서버와 통신이 실패하지 않는다면 낙관적 업데이트로 대부분을 해결해보려고 하였으나
이 방법이 생각보다 많이 복잡하고 또 상위 문서를 삭제하여 하위 문서들이 Root로 올라올 때와 같이 업데이트가 필요한 상황들로 어려움을 겪었습니다. 

전체적인 구조에 대해서는 무난한 방식으로 진행하였고 크게 두 파트 Sidebar, EditContainer로 구분하여 각 상태마다 렌더링을 다르게 하는 방식으로 진행하였습니다. 
Sidebar 부분에서는 문서리스트에 대한 state만을 가져오고 부족한 부분은 url의 id 값을 활용하려고 노력하였습니다.
EditContainer 부분은 url의 id를 fetch하여 그 상태를 사용하려고 노력하였습니다.

전반적으로 계획했던 부분과 많이 다르고 DOM을 과도하게 사용했다고 생각하고 있습니다. 또한 구현하면 좋을 것 같았지만 구현하지 못한 트리 Fold 상태 값이나 비정상적으로 종료시 내용을 불러오는 부분은 리팩토링에서 꼭 구현해보겠습니다.


- state를 크게 두개로 나눠 다루려고 했는데(문서 리스트, 문서 내용) 효율적이지 못한 방법일까요?
- 문서리스트를 너무 자주 fetch하지 않으려고 필요한 상황에서만 fetch를 진행하였으나 이로인해 DOM 조작을 과도하게 사용하게 되었습니다. DOM 조작은 최소화하고 데이터를 자주 가져오더라도 데이터 중심적으로 구현하는게 좋을까요?
- parent Id 값이 따로 정리되어 있지않아 BreadCrumb 컴포넌트를 구현할 때 DOM과 재귀로 최상위를 찾는 방식을 사용했는데 좋지 못한 방식일까요?
- contenteditable을 이용하려고 할 때 상태 변경이 일어나면 커서 포커스가 앞으로 이동하여 구현에 어려움을 겪었습니다. 검색 결과 커서의 위치를 저장해뒀다가 상태 변경후에 해당 위치로 보내는 방식을 사용한다고 하였는데 이 방식 말고도 다른 방식이 있을까요?
- 대부분의 오류가 상태값이 예상한 값이 아닐 때 일어나 방어 코드를 적는데 많은 시간을 소비했습니다. 완벽한 방어코드를 작성했다는 생각이 들지 않는데 방어 코드를 작성하는 꿀팁이 있을까요?🥲
